### PR TITLE
fix: ignore the update dependencies from metadata workflow

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,2 +1,2 @@
 CODEOWNERS
-workflows/update-dependencies.yml
+workflows/update-dependencies-from-metadata.yml


### PR DESCRIPTION
## Describe your changes

Add `workflows/update-dependencies-from-metadata.yml` to sync ignore.

This buildpack does not have such dependencies thus this workflow does not make sense.