### PR TITLE
feat: update opt-in handling

### DIFF
--- a/build.go
+++ b/build.go
@@ -44,7 +44,7 @@ func Build(
 		planEntries := filtered(context.Plan.Entries, pipinstall.SitePackages)
 		// Ignore entry as it is used to opt into using only the
 		// python-package-managers-* duo of buildpacks
-		planEntries = filtered(planEntries, PackageManagersPlanEntry)
+		planEntries = filtered(planEntries, PackageManagersRunPlanEntry)
 		layers := []packit.Layer{}
 
 		for _, entry := range planEntries {

--- a/build_test.go
+++ b/build_test.go
@@ -247,7 +247,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			buildContext.Plan = plan
 			buildContext.Plan.Entries = append(buildContext.Plan.Entries,
 				packit.BuildpackPlanEntry{
-					Name: pythonpackagers.PackageManagersPlanEntry,
+					Name: pythonpackagers.PackageManagersRunPlanEntry,
 				},
 			)
 			result, err := buildFunc(buildContext)

--- a/constants.go
+++ b/constants.go
@@ -6,6 +6,7 @@
 package pythonpackagers
 
 const (
-	PackageManagersEnv          = "BP_ENABLE_PACKAGE_MANAGERS"
-	PackageManagersRunPlanEntry = "package-managers-run"
+	PackageManagersEnv              = "BP_ENABLE_PACKAGE_MANAGERS"
+	PackageManagersRunPlanEntry     = "package-managers-run"
+	PackageManagersInstallPlanEntry = "package-managers-install"
 )

--- a/constants.go
+++ b/constants.go
@@ -6,6 +6,6 @@
 package pythonpackagers
 
 const (
-	PackageManagersEnv       = "BP_ENABLE_PACKAGE_MANAGERS"
-	PackageManagersPlanEntry = "package-managers"
+	PackageManagersEnv          = "BP_ENABLE_PACKAGE_MANAGERS"
+	PackageManagersRunPlanEntry = "package-managers-run"
 )

--- a/detect.go
+++ b/detect.go
@@ -107,6 +107,9 @@ func Detect(logger scribe.Emitter) packit.DetectFunc {
 			result.Plan.Provides = append(result.Plan.Provides, packit.BuildPlanProvision{
 				Name: PackageManagersRunPlanEntry,
 			})
+			result.Plan.Requires = append(result.Plan.Requires, packit.BuildPlanRequirement{
+				Name: PackageManagersInstallPlanEntry,
+			})
 		}
 
 		return result, err

--- a/detect.go
+++ b/detect.go
@@ -105,7 +105,7 @@ func Detect(logger scribe.Emitter) packit.DetectFunc {
 
 		if shouldUsePackageManagers {
 			result.Plan.Provides = append(result.Plan.Provides, packit.BuildPlanProvision{
-				Name: PackageManagersPlanEntry,
+				Name: PackageManagersRunPlanEntry,
 			})
 		}
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -317,6 +317,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						"Name": Equal(pythonpackagers.PackageManagersRunPlanEntry),
 					}),
 				))
+				Expect(result.Plan.Requires).To(ContainElement(
+					gstruct.MatchAllFields(gstruct.Fields{
+						"Name":     Equal(pythonpackagers.PackageManagersInstallPlanEntry),
+						"Metadata": BeNil(),
+					}),
+				))
 			})
 		})
 

--- a/detect_test.go
+++ b/detect_test.go
@@ -314,7 +314,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Plan.Provides).To(ContainElement(
 					gstruct.MatchAllFields(gstruct.Fields{
-						"Name": Equal(pythonpackagers.PackageManagersPlanEntry),
+						"Name": Equal(pythonpackagers.PackageManagersRunPlanEntry),
 					}),
 				))
 			})

--- a/integration/packagers/testdata/conda/pm_mandatory_app/plan.toml
+++ b/integration/packagers/testdata/conda/pm_mandatory_app/plan.toml
@@ -4,4 +4,4 @@ name = "conda-environment"
     launch = true
 
 [[requires]]
-name = "package-managers"
+name = "package-managers-run"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR does two things:

- Refactor the current opt-in handling (renaming things)
- Handle the python-package-managers-install opt-in

## Use Cases
<!-- An explanation of the use cases your change enables -->

Allow people that want to opt-in the use of python-package-managers-install/run to properly request them.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
