### PR TITLE
fix(uv): make cache sha check install groups

### DIFF
--- a/integration/packagers/testdata/uv/default_app/pyproject.toml
+++ b/integration/packagers/testdata/uv/default_app/pyproject.toml
@@ -10,3 +10,6 @@ dependencies = [
 dev = [
     "ruff",
 ]
+
+[tool.uv]
+default-groups = []

--- a/integration/packagers/uv_default_test.go
+++ b/integration/packagers/uv_default_test.go
@@ -113,6 +113,95 @@ func uvTestDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		it("rebuilds an oci image but reuses cache", func() {
+			var err error
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			// Rebuild should reuse cached layer
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).NotTo(ContainLines(
+				"  Executing build process",
+			))
+			Expect(logs).To(ContainLines(
+				fmt.Sprintf("  Reusing cached layer /layers/%s/uv-env", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+			))
+
+			container, err = docker.Container.Run.
+				WithCommand("python server.py").
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, world!")).OnPort(8080))
+		})
+
+		it("rebuilds an oci image that has the correct behavior when install group changed", func() {
+			var err error
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			// Rebuild with dev group: should trigger a rebuild (not reuse cached layer)
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).
+				WithEnv(map[string]string{
+					"BP_UV_INSTALL_GROUPS": "dev",
+				}).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).To(ContainLines(
+				"  Executing build process",
+			))
+			Expect(logs).NotTo(ContainLines(
+				fmt.Sprintf("  Reusing cached layer /layers/%s/uv-env", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+			))
+
+			container, err = docker.Container.Run.
+				WithCommand("python server.py").
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, world!")).OnPort(8080))
+		})
+
 		context("validating SBOM", func() {
 			var (
 				sbomDir string

--- a/pkg/packagers/uv/build.go
+++ b/pkg/packagers/uv/build.go
@@ -108,7 +108,7 @@ func Build(
 			logger.EnvironmentVariables(uvLayer)
 
 			uvLayer.Metadata = map[string]interface{}{
-				LockfileShaName: sha,
+				UvEnvLayerCacheSha: sha,
 			}
 		} else {
 			logger.Process("Reusing cached layer %s", uvLayer.Path)

--- a/pkg/packagers/uv/constants.go
+++ b/pkg/packagers/uv/constants.go
@@ -19,10 +19,18 @@ const (
 	// dependency that this buildpack requires.
 	UvPlanEntry = "uv"
 
-	// LockfileShaName is the key in the Layer Content Metadata used to determine if layer
+	// UvEnvLayerCacheSha is the key in the Layer Content Metadata used to determine if layer
 	// can be reused.
-	LockfileShaName = "lockfile-sha"
+	UvEnvLayerCacheSha = "layer-cache-sha"
 
 	// LockfileName is the name of the export file from which the buildpack reinstalls packages
 	LockfileName = "uv.lock"
+
+	// Config environmental variables
+
+	// Used to specify one or more directories to pass to `--find-links`
+	UvFindLinks = "BP_UV_FIND_LINKS"
+
+	// List of additional groups divided by comma which should be installed
+	UvInstallGroups = "BP_UV_INSTALL_GROUPS"
 )

--- a/pkg/packagers/uv/uv_runner.go
+++ b/pkg/packagers/uv/uv_runner.go
@@ -6,6 +6,7 @@
 package uvinstall
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -39,9 +40,9 @@ func NewUvRunner(executable executable.Executable, summer summer.Summer, logger 
 // ShouldRun determines whether the uv environment setup command needs to be
 // run, given the path to the app directory and the metadata from the
 // preexisting uv-env layer. It returns true if the uv environment setup
-// command must be run during this build, the SHA256 of the uv.lock in
-// the app directory, and an error. If there is no uv.lock, the sha
-// returned is an empty string.
+// command must be run during this build, the SHA256 of combination of
+// the uv.lock in the app directory and specified installed groups and an error.
+// If there is no uv.lock, the sha returned as an empty string.
 func (c UvRunner) ShouldRun(workingDir string, metadata map[string]interface{}) (run bool, sha string, err error) {
 	lockfilePath := filepath.Join(workingDir, LockfileName)
 	_, err = os.Stat(lockfilePath)
@@ -54,16 +55,23 @@ func (c UvRunner) ShouldRun(workingDir string, metadata map[string]interface{}) 
 		return false, "", err
 	}
 
-	updatedLockfileSha, err := c.summer.Sum(lockfilePath)
+	generatedSha, err := c.summer.Sum(lockfilePath)
 	if err != nil {
 		return false, "", err
 	}
 
-	if updatedLockfileSha == metadata[LockfileShaName] {
-		return false, updatedLockfileSha, nil
+	installGroups, installGroupsPresent := os.LookupEnv(UvInstallGroups)
+	if installGroupsPresent {
+		h := sha256.New()
+		h.Write([]byte(installGroups))
+		generatedSha = fmt.Sprintf("%s-%x", generatedSha, h.Sum(nil))
 	}
 
-	return true, updatedLockfileSha, nil
+	if generatedSha == metadata[UvEnvLayerCacheSha] {
+		return false, generatedSha, nil
+	}
+
+	return true, generatedSha, nil
 }
 
 // Execute runs the uv environment setup command and cleans up unnecessary
@@ -82,7 +90,7 @@ func (c UvRunner) Execute(uvLayerPath string, uvCachePath string, workingDir str
 
 	venvPath := filepath.Join(uvLayerPath, "venv")
 
-	userFindLinks, _ := os.LookupEnv("BP_UV_FIND_LINKS")
+	userFindLinks, _ := os.LookupEnv(UvFindLinks)
 	findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
 
 	combinedFindLinks := []string{userFindLinks, findLinks}
@@ -112,7 +120,7 @@ func (c UvRunner) Execute(uvLayerPath string, uvCachePath string, workingDir str
 	}
 	env = append(env, fmt.Sprintf("UV_FIND_LINKS=%s", strings.TrimLeft(strings.Join(combinedFindLinks, " "), " ")))
 
-	installGroups, installGroupsPresent := os.LookupEnv("BP_UV_INSTALL_GROUPS")
+	installGroups, installGroupsPresent := os.LookupEnv(UvInstallGroups)
 	if installGroupsPresent {
 		for _, group := range strings.Split(installGroups, ",") {
 			args = append(args, fmt.Sprintf("--group=%s", group))

--- a/pkg/packagers/uv/uv_runner_test.go
+++ b/pkg/packagers/uv/uv_runner_test.go
@@ -7,6 +7,7 @@ package uvinstall_test
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -99,18 +100,22 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			it.Before(func() {
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
+			it.After(func() {
+				Expect(os.Unsetenv(uv.UvInstallGroups)).To(Succeed())
+			})
+
 			context("and the lockfile sha is unchanged", func() {
 				it("return false, with the existing sha, and no error", func() {
 					summer.SumCall.Returns.String = "a-sha"
 					Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 
 					metadata := map[string]interface{}{
-						"lockfile-sha": "a-sha",
+						uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
 					}
 
 					run, sha, err := runner.ShouldRun(workingDir, metadata)
+					Expect(sha).To(Equal(summer.SumCall.Returns.String))
 					Expect(run).To(BeFalse())
-					Expect(sha).To(Equal("a-sha"))
 					Expect(err).NotTo(HaveOccurred())
 				})
 				context("and there is and error summing the lock file", func() {
@@ -131,12 +136,29 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			it("returns true, with a new sha, and no error when the lockfile has changed", func() {
 				summer.SumCall.Returns.String = "a-new-sha"
 				metadata := map[string]interface{}{
-					uv.LockfileShaName: "a-sha",
+					uv.UvEnvLayerCacheSha: "a-old-sha",
 				}
 
 				run, sha, err := runner.ShouldRun(workingDir, metadata)
+				Expect(sha).To(Equal(summer.SumCall.Returns.String))
 				Expect(run).To(BeTrue())
-				Expect(sha).To(Equal("a-new-sha"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns true, with a new sha, and no error when groups are specified", func() {
+				Expect(os.Setenv(uv.UvInstallGroups, "dev,local")).To(Succeed())
+				summer.SumCall.Returns.String = "a-new-sha"
+				metadata := map[string]interface{}{
+					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
+				}
+				installGroups, _ := os.LookupEnv(uv.UvInstallGroups)
+				h := sha256.New()
+				h.Write([]byte(installGroups))
+				generatedSha := fmt.Sprintf("%s-%x", summer.SumCall.Returns.String, h.Sum(nil))
+
+				run, sha, err := runner.ShouldRun(workingDir, metadata)
+				Expect(sha).To(Equal(generatedSha))
+				Expect(run).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -169,7 +191,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 				Expect(executions[0].Env).To(ContainElement("UV_PYTHON=/layers/paketo-buildpacks_cpython/cpython/bin/python"))
 				Expect(executions[0].Env).To(ContainElement("UV_OFFLINE=1"))
 				Expect(executions[0].Env).To(ContainElement("LD_LIBRARY_PATH=/layers/paketo-buildpacks_cpython/cpython/lib"))
-				userFindLinks, _ := os.LookupEnv("BP_UV_FIND_LINKS")
+				userFindLinks, _ := os.LookupEnv(uv.UvFindLinks)
 				findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
 				combinedFindLinks := []string{userFindLinks, findLinks}
 				combinedFindLinks = append(combinedFindLinks, vendorPath)
@@ -237,7 +259,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_PROJECT_ENVIRONMENT=%s", venvPath)))
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_WORKING_DIR=%s", workingDir)))
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_CACHE_DIR=%s", uvCachePath)))
-				userFindLinks, _ := os.LookupEnv("BP_UV_FIND_LINKS")
+				userFindLinks, _ := os.LookupEnv(uv.UvFindLinks)
 				findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
 				combinedFindLinks := []string{userFindLinks, findLinks}
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_FIND_LINKS=%s", strings.TrimLeft(strings.Join(combinedFindLinks, " "), " "))))
@@ -271,13 +293,13 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 
 		context("when a lockfile exists with groups specified", func() {
 			it.Before(func() {
-				Expect(os.Setenv("BP_UV_INSTALL_GROUPS", "dev,local")).To(Succeed())
+				Expect(os.Setenv(uv.UvInstallGroups, "dev,local")).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
 
 			it.After(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
-				Expect(os.Unsetenv("BP_UV_INSTALL_GROUPS")).To(Succeed())
+				Expect(os.Unsetenv(uv.UvInstallGroups)).To(Succeed())
 			})
 
 			it("runs uv create with the cache layer available in the environment", func() {
@@ -298,7 +320,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_PROJECT_ENVIRONMENT=%s", venvPath)))
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_WORKING_DIR=%s", workingDir)))
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_CACHE_DIR=%s", uvCachePath)))
-				userFindLinks, _ := os.LookupEnv("BP_UV_FIND_LINKS")
+				userFindLinks, _ := os.LookupEnv(uv.UvFindLinks)
 				findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
 				combinedFindLinks := []string{userFindLinks, findLinks}
 				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_FIND_LINKS=%s", strings.TrimLeft(strings.Join(combinedFindLinks, " "), " "))))


### PR DESCRIPTION
## Summary
Extend the sha for lockfile generation for UV to take into account installed groups

## Use Cases
When specifying a different install group, buildpack reuses the layer instead of installing/removing dependencies

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
