### PR TITLE
feat(uv): add extra uv options

### DIFF
--- a/integration/packagers/uv_default_test.go
+++ b/integration/packagers/uv_default_test.go
@@ -113,6 +113,108 @@ func uvTestDefault(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		it("rebuilds an oci image with locked enabled", func() {
+			var err error
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).WithEnv(map[string]string{
+				"BP_UV_LOCKED": "1",
+			}).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).To(ContainLines(
+				"  Executing build process",
+			))
+			Expect(logs).To(ContainLines(
+				"    UV_LOCKED=1",
+			))
+
+			container, err = docker.Container.Run.
+				WithCommand("python server.py").
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, world!")).OnPort(8080))
+		})
+
+		it("rebuilds an oci image with bytecode compilation enabled", func() {
+			var err error
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).WithEnv(map[string]string{
+				"BP_UV_COMPILE_BYTECODE": "1",
+			}).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).To(ContainLines(
+				"  Executing build process",
+			))
+			Expect(logs).To(ContainLines(
+				"    UV_COMPILE_BYTECODE=1",
+			))
+
+			container, err = docker.Container.Run.
+				WithCommand("python server.py").
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, world!")).OnPort(8080))
+		})
+
+		it("rebuilds an oci image with preview enabled", func() {
+			var err error
+
+			var logs fmt.Stringer
+			image, logs, err = pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					settings.Buildpacks.PythonPackageManagersInstall.Online,
+					settings.Buildpacks.PythonPackageManagersRun.Online,
+					settings.Buildpacks.BuildPlan.Online,
+				).WithEnv(map[string]string{
+				"BP_UV_PREVIEW": "1",
+			}).
+				Execute(name, source)
+			Expect(err).NotTo(HaveOccurred(), logs.String())
+
+			Expect(logs).To(ContainLines(
+				"  Executing build process",
+			))
+			Expect(logs).To(ContainLines(
+				"    UV_PREVIEW=1",
+			))
+
+			container, err = docker.Container.Run.
+				WithCommand("python server.py").
+				WithEnv(map[string]string{"PORT": "8080"}).
+				WithPublish("8080").
+				Execute(image.ID)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(container).Should(BeAvailable())
+			Eventually(container).Should(Serve(ContainSubstring("Hello, world!")).OnPort(8080))
+		})
+
 		it("rebuilds an oci image but reuses cache", func() {
 			var err error
 

--- a/pkg/packagers/uv/README.md
+++ b/pkg/packagers/uv/README.md
@@ -74,3 +74,32 @@ to install. This should be a comma-separated list of group names.
 ```shell
 BP_UV_INSTALL_GROUPS=dev,test
 ```
+
+### `BP_UV_LOCKED`
+
+The `BP_UV_LOCKED` variable, when set, asserts that the `uv.lock` file remains
+unchanged. uv will exit with an error if the lock file is not up-to-date with
+the `pyproject.toml`.
+
+```shell
+BP_UV_LOCKED=1
+```
+
+### `BP_UV_COMPILE_BYTECODE`
+
+The `BP_UV_COMPILE_BYTECODE` variable, when set, instructs uv to compile
+Python source files to bytecode after installation. This can improve startup
+time of the application.
+
+```shell
+BP_UV_COMPILE_BYTECODE=1
+```
+
+### `BP_UV_PREVIEW`
+
+The `BP_UV_PREVIEW` variable, when set, enables preview mode for uv. This
+allows the use of experimental uv features.
+
+```shell
+BP_UV_PREVIEW=1
+```

--- a/pkg/packagers/uv/constants.go
+++ b/pkg/packagers/uv/constants.go
@@ -33,4 +33,13 @@ const (
 
 	// List of additional groups divided by comma which should be installed
 	UvInstallGroups = "BP_UV_INSTALL_GROUPS"
+
+	// UV will assert that the uv.lock remains unchanged
+	UvLocked = "BP_UV_LOCKED"
+
+	// UV will compile Python source files to bytecode after installation
+	UvCompileByteCode = "BP_UV_COMPILE_BYTECODE"
+
+	// Enables preview mode for uv
+	UvPreview = "BP_UV_PREVIEW"
 )

--- a/pkg/packagers/uv/uv_runner.go
+++ b/pkg/packagers/uv/uv_runner.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/paketo-buildpacks/packit/v2/fs"
@@ -66,16 +67,16 @@ func (c UvRunner) ShouldRun(workingDir string, metadata map[string]interface{}) 
 		h.Write([]byte(installGroups))
 		generatedSha = fmt.Sprintf("%s-%x", generatedSha, h.Sum(nil))
 	}
-	_, uvLockedPresent := os.LookupEnv(UvLocked)
-	if uvLockedPresent {
+	uvLocked, uvLockedPresent := os.LookupEnv(UvLocked)
+	if uvLockedPresent && slices.Contains([]string{"1", "true"}, uvLocked) {
 		generatedSha = fmt.Sprintf("%s-%x", generatedSha, "locked")
 	}
-	_, uvCompileByteCodePresent := os.LookupEnv(UvCompileByteCode)
-	if uvCompileByteCodePresent {
+	uvCompileByteCode, uvCompileByteCodePresent := os.LookupEnv(UvCompileByteCode)
+	if uvCompileByteCodePresent && slices.Contains([]string{"1", "true"}, uvCompileByteCode) {
 		generatedSha = fmt.Sprintf("%s-%x", generatedSha, "compile-byte-code")
 	}
-	_, uvPreviewPresent := os.LookupEnv(UvPreview)
-	if uvPreviewPresent {
+	uvPreview, uvPreviewPresent := os.LookupEnv(UvPreview)
+	if uvPreviewPresent && slices.Contains([]string{"1", "true"}, uvPreview) {
 		generatedSha = fmt.Sprintf("%s-%x", generatedSha, "preview")
 	}
 
@@ -138,16 +139,17 @@ func (c UvRunner) Execute(uvLayerPath string, uvCachePath string, workingDir str
 			args = append(args, fmt.Sprintf("--group=%s", group))
 		}
 	}
-	_, uvLockedPresent := os.LookupEnv(UvLocked)
-	if uvLockedPresent {
+
+	uvLocked, uvLockedPresent := os.LookupEnv(UvLocked)
+	if uvLockedPresent && slices.Contains([]string{"1", "true"}, uvLocked) {
 		env = append(env, "UV_LOCKED=1")
 	}
-	_, uvCompileByteCodePresent := os.LookupEnv(UvCompileByteCode)
-	if uvCompileByteCodePresent {
+	uvCompileByteCode, uvCompileByteCodePresent := os.LookupEnv(UvCompileByteCode)
+	if uvCompileByteCodePresent && slices.Contains([]string{"1", "true"}, uvCompileByteCode) {
 		env = append(env, "UV_COMPILE_BYTECODE=1")
 	}
-	_, uvPreviewPresent := os.LookupEnv(UvPreview)
-	if uvPreviewPresent {
+	uvPreview, uvPreviewPresent := os.LookupEnv(UvPreview)
+	if uvPreviewPresent && slices.Contains([]string{"1", "true"}, uvPreview) {
 		env = append(env, "UV_PREVIEW=1")
 	}
 

--- a/pkg/packagers/uv/uv_runner.go
+++ b/pkg/packagers/uv/uv_runner.go
@@ -66,6 +66,18 @@ func (c UvRunner) ShouldRun(workingDir string, metadata map[string]interface{}) 
 		h.Write([]byte(installGroups))
 		generatedSha = fmt.Sprintf("%s-%x", generatedSha, h.Sum(nil))
 	}
+	_, uvLockedPresent := os.LookupEnv(UvLocked)
+	if uvLockedPresent {
+		generatedSha = fmt.Sprintf("%s-%x", generatedSha, "locked")
+	}
+	_, uvCompileByteCodePresent := os.LookupEnv(UvCompileByteCode)
+	if uvCompileByteCodePresent {
+		generatedSha = fmt.Sprintf("%s-%x", generatedSha, "compile-byte-code")
+	}
+	_, uvPreviewPresent := os.LookupEnv(UvPreview)
+	if uvPreviewPresent {
+		generatedSha = fmt.Sprintf("%s-%x", generatedSha, "preview")
+	}
 
 	if generatedSha == metadata[UvEnvLayerCacheSha] {
 		return false, generatedSha, nil
@@ -125,6 +137,18 @@ func (c UvRunner) Execute(uvLayerPath string, uvCachePath string, workingDir str
 		for _, group := range strings.Split(installGroups, ",") {
 			args = append(args, fmt.Sprintf("--group=%s", group))
 		}
+	}
+	_, uvLockedPresent := os.LookupEnv(UvLocked)
+	if uvLockedPresent {
+		env = append(env, "UV_LOCKED=1")
+	}
+	_, uvCompileByteCodePresent := os.LookupEnv(UvCompileByteCode)
+	if uvCompileByteCodePresent {
+		env = append(env, "UV_COMPILE_BYTECODE=1")
+	}
+	_, uvPreviewPresent := os.LookupEnv(UvPreview)
+	if uvPreviewPresent {
+		env = append(env, "UV_PREVIEW=1")
 	}
 
 	c.logger.Subprocess("%s\nRunning 'uv %s'", strings.Join(env, "\n"), strings.Join(args, " "))

--- a/pkg/packagers/uv/uv_runner_test.go
+++ b/pkg/packagers/uv/uv_runner_test.go
@@ -102,6 +102,9 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			})
 			it.After(func() {
 				Expect(os.Unsetenv(uv.UvInstallGroups)).To(Succeed())
+				Expect(os.Unsetenv(uv.UvLocked)).To(Succeed())
+				Expect(os.Unsetenv(uv.UvCompileByteCode)).To(Succeed())
+				Expect(os.Unsetenv(uv.UvPreview)).To(Succeed())
 			})
 
 			context("and the lockfile sha is unchanged", func() {
@@ -155,6 +158,48 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 				h := sha256.New()
 				h.Write([]byte(installGroups))
 				generatedSha := fmt.Sprintf("%s-%x", summer.SumCall.Returns.String, h.Sum(nil))
+
+				run, sha, err := runner.ShouldRun(workingDir, metadata)
+				Expect(sha).To(Equal(generatedSha))
+				Expect(run).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns true, with a new sha, and no error when locked is enabled", func() {
+				Expect(os.Setenv(uv.UvLocked, "1")).To(Succeed())
+				summer.SumCall.Returns.String = "a-new-sha"
+				metadata := map[string]interface{}{
+					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
+				}
+				generatedSha := fmt.Sprintf("%s-%x", summer.SumCall.Returns.String, "locked")
+
+				run, sha, err := runner.ShouldRun(workingDir, metadata)
+				Expect(sha).To(Equal(generatedSha))
+				Expect(run).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns true, with a new sha, and no error when bytecode compilation is enabled", func() {
+				Expect(os.Setenv(uv.UvCompileByteCode, "1")).To(Succeed())
+				summer.SumCall.Returns.String = "a-new-sha"
+				metadata := map[string]interface{}{
+					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
+				}
+				generatedSha := fmt.Sprintf("%s-%x", summer.SumCall.Returns.String, "compile-byte-code")
+
+				run, sha, err := runner.ShouldRun(workingDir, metadata)
+				Expect(sha).To(Equal(generatedSha))
+				Expect(run).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns true, with a new sha, and no error when preview is enabled", func() {
+				Expect(os.Setenv(uv.UvPreview, "1")).To(Succeed())
+				summer.SumCall.Returns.String = "a-new-sha"
+				metadata := map[string]interface{}{
+					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
+				}
+				generatedSha := fmt.Sprintf("%s-%x", summer.SumCall.Returns.String, "preview")
 
 				run, sha, err := runner.ShouldRun(workingDir, metadata)
 				Expect(sha).To(Equal(generatedSha))
@@ -351,6 +396,184 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			})
 
 		})
+
+		context("when a lockfile exists with locked enabled", func() {
+			it.Before(func() {
+				Expect(os.Setenv(uv.UvLocked, "1")).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
+				Expect(os.Unsetenv(uv.UvLocked)).To(Succeed())
+			})
+
+			it("runs uv sync with UV_LOCKED set in the environment", func() {
+				err := runner.Execute(uvLayerPath, uvCachePath, workingDir)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(executable.ExecuteCall.CallCount).To(Equal(1))
+
+				Expect(executions[0].Args).To(Equal([]string{
+					"sync",
+				}))
+				venvPath := filepath.Join(uvLayerPath, "venv")
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("HOME=%s", uvLayerPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("VIRTUAL_ENV=%s", venvPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_PROJECT_ENVIRONMENT=%s", venvPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_WORKING_DIR=%s", workingDir)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_CACHE_DIR=%s", uvCachePath)))
+				Expect(executions[0].Env).To(ContainElement("UV_LOCKED=1"))
+				userFindLinks, _ := os.LookupEnv(uv.UvFindLinks)
+				findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
+				combinedFindLinks := []string{userFindLinks, findLinks}
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_FIND_LINKS=%s", strings.TrimLeft(strings.Join(combinedFindLinks, " "), " "))))
+			})
+
+			context("failure cases", func() {
+				context("when the uv env command fails to run", func() {
+					it.Before(func() {
+						executable.ExecuteCall.Stub = func(ex pexec.Execution) error {
+							_, err := fmt.Fprintln(ex.Stdout, "uv error stdout")
+							Expect(err).NotTo(HaveOccurred())
+							_, err = fmt.Fprintln(ex.Stderr, "uv error stderr")
+							Expect(err).NotTo(HaveOccurred())
+							return errors.New("some uv failure")
+						}
+					})
+
+					it("returns an error and logs the stdout and stderr output from the command", func() {
+						err := runner.Execute(uvLayerPath, uvCachePath, workingDir)
+						Expect(err).To(MatchError("failed to run uv command: some uv failure"))
+						Expect(buffer.String()).To(ContainLines(
+							"    Running 'uv sync'",
+							"      uv error stdout",
+							"      uv error stderr",
+						))
+					})
+				})
+			})
+
+		})
+
+		context("when a lockfile exists with bytecode compilation enabled", func() {
+			it.Before(func() {
+				Expect(os.Setenv(uv.UvCompileByteCode, "1")).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
+				Expect(os.Unsetenv(uv.UvCompileByteCode)).To(Succeed())
+			})
+
+			it("runs uv sync with UV_COMPILE_BYTECODE set in the environment", func() {
+				err := runner.Execute(uvLayerPath, uvCachePath, workingDir)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(executable.ExecuteCall.CallCount).To(Equal(1))
+
+				Expect(executions[0].Args).To(Equal([]string{
+					"sync",
+				}))
+				venvPath := filepath.Join(uvLayerPath, "venv")
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("HOME=%s", uvLayerPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("VIRTUAL_ENV=%s", venvPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_PROJECT_ENVIRONMENT=%s", venvPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_WORKING_DIR=%s", workingDir)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_CACHE_DIR=%s", uvCachePath)))
+				Expect(executions[0].Env).To(ContainElement("UV_COMPILE_BYTECODE=1"))
+				userFindLinks, _ := os.LookupEnv(uv.UvFindLinks)
+				findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
+				combinedFindLinks := []string{userFindLinks, findLinks}
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_FIND_LINKS=%s", strings.TrimLeft(strings.Join(combinedFindLinks, " "), " "))))
+			})
+
+			context("failure cases", func() {
+				context("when the uv env command fails to run", func() {
+					it.Before(func() {
+						executable.ExecuteCall.Stub = func(ex pexec.Execution) error {
+							_, err := fmt.Fprintln(ex.Stdout, "uv error stdout")
+							Expect(err).NotTo(HaveOccurred())
+							_, err = fmt.Fprintln(ex.Stderr, "uv error stderr")
+							Expect(err).NotTo(HaveOccurred())
+							return errors.New("some uv failure")
+						}
+					})
+
+					it("returns an error and logs the stdout and stderr output from the command", func() {
+						err := runner.Execute(uvLayerPath, uvCachePath, workingDir)
+						Expect(err).To(MatchError("failed to run uv command: some uv failure"))
+						Expect(buffer.String()).To(ContainLines(
+							"    Running 'uv sync'",
+							"      uv error stdout",
+							"      uv error stderr",
+						))
+					})
+				})
+			})
+
+		})
+
+		context("when a lockfile exists with preview enabled", func() {
+			it.Before(func() {
+				Expect(os.Setenv(uv.UvPreview, "1")).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
+				Expect(os.Unsetenv(uv.UvPreview)).To(Succeed())
+			})
+
+			it("runs uv sync with UV_PREVIEW set in the environment", func() {
+				err := runner.Execute(uvLayerPath, uvCachePath, workingDir)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(executable.ExecuteCall.CallCount).To(Equal(1))
+
+				Expect(executions[0].Args).To(Equal([]string{
+					"sync",
+				}))
+				venvPath := filepath.Join(uvLayerPath, "venv")
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("HOME=%s", uvLayerPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("VIRTUAL_ENV=%s", venvPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_PROJECT_ENVIRONMENT=%s", venvPath)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_WORKING_DIR=%s", workingDir)))
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_CACHE_DIR=%s", uvCachePath)))
+				Expect(executions[0].Env).To(ContainElement("UV_PREVIEW=1"))
+				userFindLinks, _ := os.LookupEnv(uv.UvFindLinks)
+				findLinks, _ := os.LookupEnv("UV_FIND_LINKS")
+				combinedFindLinks := []string{userFindLinks, findLinks}
+				Expect(executions[0].Env).To(ContainElement(fmt.Sprintf("UV_FIND_LINKS=%s", strings.TrimLeft(strings.Join(combinedFindLinks, " "), " "))))
+			})
+
+			context("failure cases", func() {
+				context("when the uv env command fails to run", func() {
+					it.Before(func() {
+						executable.ExecuteCall.Stub = func(ex pexec.Execution) error {
+							_, err := fmt.Fprintln(ex.Stdout, "uv error stdout")
+							Expect(err).NotTo(HaveOccurred())
+							_, err = fmt.Fprintln(ex.Stderr, "uv error stderr")
+							Expect(err).NotTo(HaveOccurred())
+							return errors.New("some uv failure")
+						}
+					})
+
+					it("returns an error and logs the stdout and stderr output from the command", func() {
+						err := runner.Execute(uvLayerPath, uvCachePath, workingDir)
+						Expect(err).To(MatchError("failed to run uv command: some uv failure"))
+						Expect(buffer.String()).To(ContainLines(
+							"    Running 'uv sync'",
+							"      uv error stdout",
+							"      uv error stderr",
+						))
+					})
+				})
+			})
+
+		})
+
 		context("when no vendor dir or lockfile exists", func() {
 			context("failure cases", func() {
 				context("when no lockfile exists", func() {

--- a/pkg/packagers/uv/uv_runner_test.go
+++ b/pkg/packagers/uv/uv_runner_test.go
@@ -101,10 +101,6 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
 			it.After(func() {
-				Expect(os.Unsetenv(uv.UvInstallGroups)).To(Succeed())
-				Expect(os.Unsetenv(uv.UvLocked)).To(Succeed())
-				Expect(os.Unsetenv(uv.UvCompileByteCode)).To(Succeed())
-				Expect(os.Unsetenv(uv.UvPreview)).To(Succeed())
 			})
 
 			context("and the lockfile sha is unchanged", func() {
@@ -149,7 +145,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns true, with a new sha, and no error when groups are specified", func() {
-				Expect(os.Setenv(uv.UvInstallGroups, "dev,local")).To(Succeed())
+				t.Setenv(uv.UvInstallGroups, "dev,local")
 				summer.SumCall.Returns.String = "a-new-sha"
 				metadata := map[string]interface{}{
 					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
@@ -166,7 +162,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns true, with a new sha, and no error when locked is enabled", func() {
-				Expect(os.Setenv(uv.UvLocked, "1")).To(Succeed())
+				t.Setenv(uv.UvLocked, "1")
 				summer.SumCall.Returns.String = "a-new-sha"
 				metadata := map[string]interface{}{
 					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
@@ -180,7 +176,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns true, with a new sha, and no error when bytecode compilation is enabled", func() {
-				Expect(os.Setenv(uv.UvCompileByteCode, "1")).To(Succeed())
+				t.Setenv(uv.UvCompileByteCode, "1")
 				summer.SumCall.Returns.String = "a-new-sha"
 				metadata := map[string]interface{}{
 					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
@@ -194,7 +190,7 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns true, with a new sha, and no error when preview is enabled", func() {
-				Expect(os.Setenv(uv.UvPreview, "1")).To(Succeed())
+				t.Setenv(uv.UvPreview, "1")
 				summer.SumCall.Returns.String = "a-new-sha"
 				metadata := map[string]interface{}{
 					uv.UvEnvLayerCacheSha: summer.SumCall.Returns.String,
@@ -338,13 +334,12 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 
 		context("when a lockfile exists with groups specified", func() {
 			it.Before(func() {
-				Expect(os.Setenv(uv.UvInstallGroups, "dev,local")).To(Succeed())
+				t.Setenv(uv.UvInstallGroups, "dev,local")
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
 
 			it.After(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
-				Expect(os.Unsetenv(uv.UvInstallGroups)).To(Succeed())
 			})
 
 			it("runs uv create with the cache layer available in the environment", func() {
@@ -399,13 +394,12 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 
 		context("when a lockfile exists with locked enabled", func() {
 			it.Before(func() {
-				Expect(os.Setenv(uv.UvLocked, "1")).To(Succeed())
+				t.Setenv(uv.UvLocked, "1")
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
 
 			it.After(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
-				Expect(os.Unsetenv(uv.UvLocked)).To(Succeed())
 			})
 
 			it("runs uv sync with UV_LOCKED set in the environment", func() {
@@ -458,13 +452,12 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 
 		context("when a lockfile exists with bytecode compilation enabled", func() {
 			it.Before(func() {
-				Expect(os.Setenv(uv.UvCompileByteCode, "1")).To(Succeed())
+				t.Setenv(uv.UvCompileByteCode, "1")
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
 
 			it.After(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
-				Expect(os.Unsetenv(uv.UvCompileByteCode)).To(Succeed())
 			})
 
 			it("runs uv sync with UV_COMPILE_BYTECODE set in the environment", func() {
@@ -517,13 +510,12 @@ func testUvRunner(t *testing.T, context spec.G, it spec.S) {
 
 		context("when a lockfile exists with preview enabled", func() {
 			it.Before(func() {
-				Expect(os.Setenv(uv.UvPreview, "1")).To(Succeed())
+				t.Setenv(uv.UvPreview, "1")
 				Expect(os.WriteFile(filepath.Join(workingDir, uv.LockfileName), nil, os.ModePerm)).To(Succeed())
 			})
 
 			it.After(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, uv.LockfileName))).To(Succeed())
-				Expect(os.Unsetenv(uv.UvPreview)).To(Succeed())
 			})
 
 			it("runs uv sync with UV_PREVIEW set in the environment", func() {


### PR DESCRIPTION
## Summary 

* BP_UV_LOCKED: Enables locked mode for uv, preventing changes to the uv.lock file during installation
* BP_UV_COMPILE_BYTECODE: Enables bytecode compilation for Python source files after installation
* BP_UV_PREVIEW: Enables preview mode for uv

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
